### PR TITLE
Remove unused NumPy imports

### DIFF
--- a/ember_ml/actors/supervisor/state_manager_actor.py
+++ b/ember_ml/actors/supervisor/state_manager_actor.py
@@ -12,7 +12,6 @@ import json
 import pickle
 import os
 import math
-import numpy as np
 from typing import Dict, List, Any, Optional
 from ember_ml.nn.tensor.types import TensorLike
 

--- a/ember_ml/actors/task/metal_kernel_actor.py
+++ b/ember_ml/actors/task/metal_kernel_actor.py
@@ -8,7 +8,6 @@ import mlx.core as mx
 import time
 import asyncio
 from typing import Dict, List, Optional, Any
-import numpy as np
 
 # Import EmberTensor and async liquid_cfc_xlstm
 from ember_ml.nn.tensor import EmberTensor

--- a/ember_ml/utils/fraction.py
+++ b/ember_ml/utils/fraction.py
@@ -6,7 +6,6 @@ This module provides utilities for working with fractions.
 
 from fractions import Fraction
 from typing import Union, Tuple, List
-import numpy as np
 
 def to_fraction(value: Union[float, int, str]) -> Fraction:
     """

--- a/ember_ml/utils/performance.py
+++ b/ember_ml/utils/performance.py
@@ -7,7 +7,6 @@ This module provides performance utilities for the ember_ml library.
 import time
 import functools
 from typing import Callable, Any, Dict, List, Optional
-import numpy as np
 import matplotlib.pyplot as plt
 
 def timeit(func: Callable) -> Callable:

--- a/ember_ml/utils/performance/memory_transfer_analysis.py
+++ b/ember_ml/utils/performance/memory_transfer_analysis.py
@@ -7,7 +7,6 @@ or if there's unnecessary data transfer happening.
 
 import time
 import torch
-import numpy as np
 
 def print_tensor_info(tensor, name):
     """Print detailed information about a tensor."""

--- a/ember_ml/utils/performance/memory_transfer_analysis_fixed.py
+++ b/ember_ml/utils/performance/memory_transfer_analysis_fixed.py
@@ -7,7 +7,6 @@ or if there's unnecessary data transfer happening.
 
 import time
 import torch
-import numpy as np
 
 def print_tensor_info(tensor, name):
     """Print detailed information about a tensor."""


### PR DESCRIPTION
## Summary
- clean up unused NumPy imports across utils and actor modules

## Testing
- `python utils/emberlint.py ember_ml/utils/fraction.py --verbose`
- `python utils/emberlint.py ember_ml/utils/performance.py --verbose`
- `python utils/emberlint.py ember_ml/utils/performance/memory_transfer_analysis.py --verbose`
- `python utils/emberlint.py ember_ml/utils/performance/memory_transfer_analysis_fixed.py --verbose`
- `python utils/emberlint.py ember_ml/actors/supervisor/state_manager_actor.py --verbose`
- `python utils/emberlint.py ember_ml/actors/task/metal_kernel_actor.py --verbose`
