### PR TITLE
Add compat modules and BigQuery feature extractor

### DIFF
--- a/ember_ml/__init__.py
+++ b/ember_ml/__init__.py
@@ -63,12 +63,14 @@ from ember_ml import visualization
 from ember_ml import wave
 from ember_ml import utils
 from ember_ml import asyncml
+from ember_ml.nn.tensor import set_seed
 # Version of the Ember ML package
 __version__ = '0.2.0'
 
 # List of public objects exported by this module
 __all__ = [
     'set_backend',
+    'set_seed',
     # 'auto_select_backend', # Removed - moved to ops
     'data',
     'models',

--- a/ember_ml/attention/__init__.py
+++ b/ember_ml/attention/__init__.py
@@ -1,0 +1,17 @@
+"""Compatibility wrapper exposing attention modules."""
+
+from ember_ml.nn.attention import *
+import ember_ml.nn.attention as _nn_attention
+from ember_ml.models.attention.multiscale_ltc import (
+    TemporalStrideProcessor,
+    build_multiscale_ltc_model,
+    visualize_feature_extraction,
+    visualize_multiscale_dynamics,
+)
+
+__all__ = list(getattr(_nn_attention, "__all__", [])) + [
+    "TemporalStrideProcessor",
+    "build_multiscale_ltc_model",
+    "visualize_feature_extraction",
+    "visualize_multiscale_dynamics",
+]

--- a/ember_ml/attention/multiscale_ltc.py
+++ b/ember_ml/attention/multiscale_ltc.py
@@ -1,0 +1,1 @@
+from ember_ml.models.attention.multiscale_ltc import *

--- a/ember_ml/features/__init__.py
+++ b/ember_ml/features/__init__.py
@@ -1,0 +1,5 @@
+from ember_ml.nn.features import *  # re-export all nn features
+import ember_ml.nn.features as _nn_features
+from .bigquery_feature_extractor import BigQueryFeatureExtractor
+
+__all__ = list(getattr(_nn_features, '__all__', [])) + ['BigQueryFeatureExtractor']

--- a/ember_ml/models/attention/__init__.py
+++ b/ember_ml/models/attention/__init__.py
@@ -5,8 +5,11 @@ This module provides implementations of attention mechanisms,
 including temporal and causal attention.
 """
 
-# Use relative import for subpackage
-from .mechanisms import CausalAttention, AttentionState
+# Import from the shared attention mechanisms package
+from ember_ml.nn.attention.mechanisms import (
+    CausalAttention,
+    AttentionState,
+)
 
 __all__ = [
     "CausalAttention",

--- a/ember_ml/models/attention/multiscale_ltc.py
+++ b/ember_ml/models/attention/multiscale_ltc.py
@@ -8,11 +8,11 @@ from ember_ml.nn import tensor
 from ember_ml.nn.tensor import EmberTensor, zeros, ones, reshape, concatenate, to_numpy, convert_to_tensor
 from ember_ml.nn.tensor import float32, shape, cast, arange, stack, pad, full
 from ember_ml.nn.modules import AutoNCP # Updated import path
-from ember_ml.nn.modules.rnn.stride_aware import StrideAwareCell
+from ember_ml.nn.modules.rnn.stride_aware_cell import StrideAwareCell
 from ember_ml.nn.modules.rnn.rnn import RNN
 from ember_ml.nn.initializers import glorot_uniform
 from ember_ml.nn.tensor import EmberTensor
-from ember_ml.nn.features import one_hot, fit_transform, fit, transform, PCA
+from ember_ml.nn.features import one_hot, PCA
 
 # The prepare_bigquery_data_bf function would be imported here in a real implementation
 # from data_utils import prepare_bigquery_data_bf

--- a/ember_ml/nn/modules/rnn/__init__.py
+++ b/ember_ml/nn/modules/rnn/__init__.py
@@ -22,6 +22,7 @@ from ember_ml.nn.modules.rnn.gru import GRU
 from ember_ml.nn.modules.rnn.rnn import RNN
 # Removed stride_aware_cell import
 from ember_ml.nn.modules.rnn.stride_aware import StrideAware
+from ember_ml.nn.modules.rnn.stride_aware_cell import StrideAwareCell
 # Temporarily comment out to avoid circular imports
 # from ember_ml.nn.modules.rnn.stride_aware_cfc import StrideAwareWiredCfCCell
 # from ember_ml.nn.modules.rnn.stride_aware_cfc_layer import StrideAwareCfC
@@ -47,6 +48,7 @@ __all__ = [
     'LSTM',
     'GRU',
     'RNN',
+    'StrideAwareCell',
     'StrideAware',
     # 'StrideAwareWiredCfCCell',  # Temporarily commented out
     # 'StrideAwareCfC',  # Temporarily commented out

--- a/ember_ml/nn/modules/rnn/stride_aware_cell.py
+++ b/ember_ml/nn/modules/rnn/stride_aware_cell.py
@@ -1,0 +1,51 @@
+"""Basic stride-aware recurrent cell."""
+
+from typing import Optional, Tuple
+
+from ember_ml import ops
+from ember_ml.nn import tensor
+from ember_ml.nn.modules import Module, Parameter
+from ember_ml.nn.modules.activations import get_activation
+from ember_ml.nn.initializers import glorot_uniform
+
+
+class StrideAwareCell(Module):
+    """Simple recurrent cell that processes inputs at a fixed stride."""
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        stride_length: int = 1,
+        time_scale_factor: float = 1.0,
+        activation: str = "tanh",
+        use_bias: bool = True,
+    ) -> None:
+        super().__init__()
+        self.input_size = input_size
+        self.hidden_size = hidden_size
+        self.stride_length = stride_length
+        self.time_scale_factor = time_scale_factor
+        self.activation = activation
+        self.use_bias = use_bias
+
+        self.input_kernel = Parameter(glorot_uniform((input_size, hidden_size)))
+        self.recurrent_kernel = Parameter(glorot_uniform((hidden_size, hidden_size)))
+        if use_bias:
+            self.bias = Parameter(tensor.zeros((hidden_size,)))
+        else:
+            self.bias = None
+
+    def forward(self, inputs, state: Optional[tensor.EmberTensor] = None) -> Tuple[tensor.EmberTensor, tensor.EmberTensor]:
+        if state is None:
+            batch_size = tensor.shape(inputs)[0]
+            state = tensor.zeros((batch_size, self.hidden_size))
+
+        output = ops.matmul(inputs, self.input_kernel.data)
+        output = ops.add(output, ops.matmul(state, self.recurrent_kernel.data))
+        if self.bias is not None:
+            output = ops.add(output, self.bias.data)
+
+        activation_fn = get_activation(self.activation)
+        new_state = activation_fn(output)
+        return new_state, new_state

--- a/ember_ml/ops/__init__.py
+++ b/ember_ml/ops/__init__.py
@@ -138,6 +138,36 @@ irfft2 = ops_module.irfft2
 rfftn = ops_module.rfftn
 irfftn = ops_module.irfftn
 
+# Provide simple random namespace for compatibility
+class _RandomNamespace:
+    def uniform(self, minval: float = 0.0, maxval: float = 1.0, shape=()):
+        from ember_ml.nn.tensor import random_uniform, squeeze
+        minval = float(getattr(minval, "item", lambda: minval)()) if not isinstance(minval, (int, float)) else minval
+        maxval = float(getattr(maxval, "item", lambda: maxval)()) if not isinstance(maxval, (int, float)) else maxval
+        if shape == ():
+            tensor = random_uniform((1,), minval=minval, maxval=maxval)
+            return float(squeeze(tensor).item())
+        return random_uniform(shape, minval=minval, maxval=maxval)
+
+    def normal(self, shape=(), mean: float = 0.0, stddev: float = 1.0):
+        from ember_ml.nn.tensor import random_normal, squeeze
+        mean = float(getattr(mean, "item", lambda: mean)()) if not isinstance(mean, (int, float)) else mean
+        stddev = float(getattr(stddev, "item", lambda: stddev)()) if not isinstance(stddev, (int, float)) else stddev
+        if shape == ():
+            tensor = random_normal((1,), mean=mean, stddev=stddev)
+            return float(squeeze(tensor).item())
+        return random_normal(shape, mean=mean, stddev=stddev)
+
+random = _RandomNamespace()
+
+# Alias tensor indexing helpers for convenience
+from ember_ml.nn import tensor as _tensor
+
+def index_update(tensor_obj, indices, value):
+    return _tensor.index_update(tensor_obj, indices, value)
+
+index = _tensor.index
+
 
 # Master list of all operations for __all__
 _MASTER_OPS_LIST = [
@@ -161,11 +191,12 @@ _MASTER_OPS_LIST = [
     'normalize_vector', 'compute_energy_stability', 'compute_interference_strength', 'compute_phase_coherence',
     'partial_interference', 'euclidean_distance', 'cosine_similarity', 'exponential_decay', 'fft', 'ifft',
     'fft2', 'ifft2', 'fftn', 'ifftn', 'rfft', 'irfft', 'rfft2', 'irfft2', 'rfftn', 'irfftn',
+    'index_update', 'index',
 ]
 
 # Define __all__ to include backend controls, pi, submodules, and all operations
 __all__ = [
     'set_backend', 'get_backend', 'auto_select_backend',  # Backend controls
     'pi',  # Constants
-    'stats', 'linearalg', 'bitwise',  # Submodules
+    'stats', 'linearalg', 'bitwise', 'random',  # Submodules
 ] + _MASTER_OPS_LIST  # All operations


### PR DESCRIPTION
## Summary
- create `ember_ml.features` compatibility package
- implement simplified `BigQueryFeatureExtractor`
- export new attention API for backwards compatibility
- add a basic `StrideAwareCell` and expose through RNN package
- expose tensor helpers and random namespace in `ops`

## Testing
- `pytest -c tests/pytest.ini ember_ml/models/attention/test_stride_aware.py::test_stride_aware_cell -q`
- `pytest -c tests/pytest.ini ember_ml/models/attention/test_temporal_stride_processor -q` *(fails: ValueError: could not broadcast input array)*
- `pytest -c tests/pytest.ini -q` *(fails due to environment requirements)*

------
https://chatgpt.com/codex/tasks/task_e_6844b2ef5818833399bc4d8c392706f4