### PR TITLE
Remove cell patterns and add BigQuery extractor

### DIFF
--- a/docs/api/nn_modules_rnn.md
+++ b/docs/api/nn_modules_rnn.md
@@ -168,7 +168,7 @@ from ember_ml.nn.modules.rnn import StrideAwareCfC
 from ember_ml.nn import tensor
 
 # Create a NeuronMap (assuming FullyConnected for this example)
-# The StrideAwareCfC layer likely expects a NeuronMap or a pre-configured stride-aware cell
+# The StrideAwareCfC layer expects a ``NeuronMap`` instance defining its wiring
 from ember_ml.nn.modules.wiring import FullyConnectedMap
 neuron_map = FullyConnectedMap(units=20, input_dim=10, output_dim=20)
 

--- a/docs/architecture/liquidneurons/cells_layers.md
+++ b/docs/architecture/liquidneurons/cells_layers.md
@@ -84,7 +84,7 @@ This section details the specific implementations of various continuous-time RNN
 
 ### `ember_ml.nn.modules.rnn.stride_aware_cfc`
 
-*   **`StrideAwareCfC(Module)`**: Implements a stride-aware CfC layer, seemingly intended to wrap a cell but currently contains the cell logic directly.
+*   **`StrideAwareCfC(Module)`**: Implements a stride-aware CfC layer that integrates multi-timescale processing directly.
     *   Inherits from `Module` (previously `ModuleWiredCell`).
     *   Includes parameters like `stride_length`, `time_scale_factor`, `mode`, `activation`, `backbone_units`, `backbone_layers`.
     *   `_initialize_weights()`: Initializes weights for input, recurrent, backbone, time gate, and gating connections. Also initializes sparsity masks.
@@ -95,6 +95,6 @@ This section details the specific implementations of various continuous-time RNN
 ### `ember_ml.models.attention.testfile` (Keras-based Implementations)
 
 *Note: These are Keras implementations found in a test file, likely prototypes or experiments.*
-*   **`StrideAwareWiredCfCCell(keras.layers.Layer)`**: A Keras Layer implementing a stride-aware CfC cell that uses a `wirings.Wiring` object for connectivity. Re-implements CfC logic with time scaling based on `stride_length` and `time_scale_factor`.
-*   **`StrideAwareCfC(keras.layers.RNN)`**: A Keras RNN layer that wraps either `StrideAwareWiredCfCCell` (if `units` is a Wiring object) or an internally defined `StrideAwareCfCCell` (if `units` is an int). Supports `mixed_memory`.
+*   **`StrideAwareWiredCfC(keras.layers.Layer)`**: Legacy Keras layer that applied stride-aware CfC dynamics using a wiring object.
+*   **`StrideAwareCfC(keras.layers.RNN)`**: Keras RNN layer that used the wired variant internally. Retained here for historical reference.
 *   **`MixedMemoryRNN(keras.layers.Layer)`**: A Keras Layer used internally by `StrideAwareCfC` when `mixed_memory` is True. It wraps an RNN cell (like the stride-aware CfC cell) and adds an LSTM-like memory gate mechanism.

--- a/docs/architecture/liquidneurons/core_concepts.md
+++ b/docs/architecture/liquidneurons/core_concepts.md
@@ -30,7 +30,7 @@ Unlike traditional RNNs (like LSTMs or GRUs) that operate on discrete time steps
 
 ## Stride Awareness
 
-*   **Multi-Timescale Processing:** Stride-aware variants (e.g., `StrideAwareCfCCell`, `StrideAwareWiredCfCCell`, `StrideAware`) are designed to process input sequences at multiple temporal resolutions simultaneously.
-*   **Stride Length:** Each stride-aware cell or layer is associated with a `stride_length`. It processes inputs only at intervals defined by this stride.
+*   **Multi-Timescale Processing:** Stride-aware layers (e.g., `StrideAwareCfC`, `StrideAware`) process input sequences at multiple temporal resolutions simultaneously.
+*   **Stride Length:** Each stride-aware layer is associated with a `stride_length` and processes inputs only at intervals defined by this stride.
 *   **Time Scaling:** Often incorporates a `time_scale_factor` (potentially learnable) that interacts with the `stride_length` to adjust the effective time constant for that specific timescale.
-*   **Implementation:** Achieved either by modifying the cell's internal dynamics based on stride and time scale factors (as seen in the Keras-based `StrideAwareWiredCfCCell` in `testfile.py`) or by controlling how inputs are fed to different cells/layers in a larger network architecture (as suggested by `MultiStrideLiquidNetwork` in `stride_aware_cfc.py`).
+*   **Implementation:** This can be achieved by modifying the layer's internal dynamics based on stride and time scale factors or by controlling how inputs are fed to different layers in a larger network architecture (as in `MultiStrideLiquidNetwork`).

--- a/docs/architecture/liquidneurons/hybrid_models.md
+++ b/docs/architecture/liquidneurons/hybrid_models.md
@@ -24,7 +24,7 @@ Hybrid models aim to leverage the strengths of different architectures. For inst
 
 ### `ember_ml.models.stride_aware_cfc` (Relevant Components)
 
-*   **`LiquidNetworkWithMotorNeuron(Module)`**: Combines a stride-aware CfC cell (`StrideAwareCfCCell`) with a `MotorNeuron`.
+*   **`LiquidNetworkWithMotorNeuron(Module)`**: Combines a stride-aware CfC layer with a `MotorNeuron`.
     *   Processes input through the CfC cell.
     *   Includes optional `mixed_memory` using a sigmoid gate applied to the cell output.
     *   Feeds the cell output to a `MotorNeuron` to generate trigger signals.
@@ -34,7 +34,7 @@ Hybrid models aim to leverage the strengths of different architectures. For inst
     *   Uses the LSTM output to compute a gate (`sigmoid` activation).
     *   Applies the gate multiplicatively to the CfC output.
     *   Concatenates the gated CfC output and the LSTM output before feeding to a final output projection layer.
-*   **`MultiStrideLiquidNetwork(Module)`**: Processes input through multiple `StrideAwareCfCCell` instances, each configured with a different stride length.
+*   **`MultiStrideLiquidNetwork(Module)`**: Processes input through multiple stride-aware CfC layers, each configured with a different stride length.
     *   Applies separate input projections for each stride.
     *   Processes input through the corresponding cell only at time steps divisible by the stride length (otherwise reuses the previous state/output).
     *   Concatenates the outputs from all stride-specific cells.

--- a/docs/architecture/neural_network_modules.md
+++ b/docs/architecture/neural_network_modules.md
@@ -230,47 +230,20 @@ Ember ML includes a variety of other neural network modules, including:
 - **LTC**: Liquid Time-Constant network
 - **CFC**: Closed-form Continuous-time network
 
-### Stride-Aware Cells
+### Stride-Aware Layers
 
-Stride-aware cells are a special type of recurrent cell that can process inputs at different time scales. They are particularly useful for processing time series data with varying sampling rates.
-
-The `StrideAwareCell` class is the base class for all stride-aware cells:
+Stride-aware layers process inputs at different time scales and are useful for irregular time series.
 
 ```python
-class StrideAwareCell(Module):
-    def __init__(self, stride_length=1, **kwargs):
+class StrideAware(Module):
+    def __init__(self, input_size, hidden_size, stride_length=1, **kwargs):
         super().__init__(**kwargs)
         self.stride_length = stride_length
-        
-    def forward(self, inputs, state=None, **kwargs):
-        # Process inputs at the current time step
-        # ...
-        
-        # Update state based on stride length
-        # ...
-        
-        return output, new_state
-```
+        # initialization omitted
 
-The `StrideAwareCfC` class extends `StrideAwareCell` to implement a stride-aware version of the Closed-form Continuous-time cell:
-
-```python
-class StrideAwareCfC(Module):
-    def __init__(
-        self,
-        units_or_cell,
-        stride_length=1,
-        # ... other parameters
-    ):
-        super().__init__()
-        
-        if isinstance(units_or_cell, StrideAwareWiredCfCCell):
-            self.cell = units_or_cell
-        elif isinstance(units_or_cell, Wiring):
-            self.cell = StrideAwareWiredCfCCell(wiring=units_or_cell, **kwargs)
-        else:
-            # Create a cell with a default wiring
-            # ...
+    def forward(self, inputs, initial_state=None):
+        # apply stride-aware processing
+        return outputs, new_state
 ```
 
 ## Integration with Backend Abstraction

--- a/ember_ml/__init__.py
+++ b/ember_ml/__init__.py
@@ -63,12 +63,14 @@ from ember_ml import visualization
 from ember_ml import wave
 from ember_ml import utils
 from ember_ml import asyncml
+from ember_ml.nn.tensor import set_seed
 # Version of the Ember ML package
 __version__ = '0.2.0'
 
 # List of public objects exported by this module
 __all__ = [
     'set_backend',
+    'set_seed',
     # 'auto_select_backend', # Removed - moved to ops
     'data',
     'models',

--- a/ember_ml/attention/__init__.py
+++ b/ember_ml/attention/__init__.py
@@ -1,0 +1,17 @@
+"""Compatibility wrapper exposing attention modules."""
+
+from ember_ml.nn.attention import *
+import ember_ml.nn.attention as _nn_attention
+from ember_ml.models.attention.multiscale_ltc import (
+    TemporalStrideProcessor,
+    build_multiscale_ltc_model,
+    visualize_feature_extraction,
+    visualize_multiscale_dynamics,
+)
+
+__all__ = list(getattr(_nn_attention, "__all__", [])) + [
+    "TemporalStrideProcessor",
+    "build_multiscale_ltc_model",
+    "visualize_feature_extraction",
+    "visualize_multiscale_dynamics",
+]

--- a/ember_ml/attention/multiscale_ltc.py
+++ b/ember_ml/attention/multiscale_ltc.py
@@ -1,0 +1,1 @@
+from ember_ml.models.attention.multiscale_ltc import *

--- a/ember_ml/features/__init__.py
+++ b/ember_ml/features/__init__.py
@@ -1,0 +1,5 @@
+from ember_ml.nn.features import *  # re-export all nn features
+import ember_ml.nn.features as _nn_features
+from .bigquery_feature_extractor import BigQueryFeatureExtractor
+
+__all__ = list(getattr(_nn_features, '__all__', [])) + ['BigQueryFeatureExtractor']

--- a/ember_ml/features/bigquery_feature_extractor.py
+++ b/ember_ml/features/bigquery_feature_extractor.py
@@ -1,0 +1,3 @@
+from ember_ml.nn.features.bigquery_feature_extractor import BigQueryFeatureExtractor
+
+__all__ = ['BigQueryFeatureExtractor']

--- a/ember_ml/models/attention/__init__.py
+++ b/ember_ml/models/attention/__init__.py
@@ -5,8 +5,11 @@ This module provides implementations of attention mechanisms,
 including temporal and causal attention.
 """
 
-# Use relative import for subpackage
-from .mechanisms import CausalAttention, AttentionState
+# Import from the shared attention mechanisms package
+from ember_ml.nn.attention.mechanisms import (
+    CausalAttention,
+    AttentionState,
+)
 
 __all__ = [
     "CausalAttention",

--- a/ember_ml/models/attention/multiscale_ltc.py
+++ b/ember_ml/models/attention/multiscale_ltc.py
@@ -8,11 +8,10 @@ from ember_ml.nn import tensor
 from ember_ml.nn.tensor import EmberTensor, zeros, ones, reshape, concatenate, to_numpy, convert_to_tensor
 from ember_ml.nn.tensor import float32, shape, cast, arange, stack, pad, full
 from ember_ml.nn.modules import AutoNCP # Updated import path
-from ember_ml.nn.modules.rnn.stride_aware import StrideAwareCell
-from ember_ml.nn.modules.rnn.rnn import RNN
+from ember_ml.nn.modules.rnn.stride_aware import StrideAware
 from ember_ml.nn.initializers import glorot_uniform
 from ember_ml.nn.tensor import EmberTensor
-from ember_ml.nn.features import one_hot, fit_transform, fit, transform, PCA
+from ember_ml.nn.features import one_hot, PCA
 
 # The prepare_bigquery_data_bf function would be imported here in a real implementation
 # from data_utils import prepare_bigquery_data_bf
@@ -88,26 +87,18 @@ def build_multiscale_ltc_model(input_dims: Dict[int, int], output_dim: int = 1,
         )
         
         # Create a stride-aware cell
-        ltc_cell = StrideAwareCell(
+        ltc_cell = StrideAware(
             input_size=dim,
             hidden_size=hidden_units,
             stride_length=stride,
             time_scale_factor=1.0,
-            activation="tanh"
-        )
-        
-        # Create an RNN layer with the cell
-        rnn = RNN(
-            input_size=dim,
-            hidden_size=hidden_units,
-            batch_first=True,
             return_sequences=False,
-            return_state=False,
-            dropout=dropout_rate
-        )
-        
-        # Process the input through the RNN
-        rnn_output = rnn(reshaped)
+            activation="tanh",
+            batch_first=True,
+            )
+
+        # Process the input through the layer
+        rnn_output, _ = ltc_cell(reshaped)
         
         # Store the output
         ltc_outputs.append(rnn_output)

--- a/ember_ml/models/attention/test_stride_aware.py
+++ b/ember_ml/models/attention/test_stride_aware.py
@@ -1,42 +1,15 @@
 """
-Test file for the StrideAwareCell and StrideAware classes.
+Example usage of the :class:`StrideAware` layer.
 
-This file demonstrates how to use the StrideAwareCell and StrideAware classes
-for multi-timescale processing.
+This file demonstrates how to use the ``StrideAware`` class for
+multi-timescale processing.
 """
 
 import numpy as np
 from ember_ml import ops
 from ember_ml.nn import tensor
-from ember_ml.nn.modules.rnn import StrideAwareCell, StrideAware
+from ember_ml.nn.modules.rnn import StrideAware
 
-def test_stride_aware_cell():
-    """Test the StrideAwareCell class."""
-    print("Testing StrideAwareCell...")
-    
-    # Create a cell
-    cell = StrideAwareCell(
-        input_size=10,
-        hidden_size=20,
-        stride_length=3,
-        time_scale_factor=1.5
-    )
-    
-    # Create input
-    batch_size = 2
-    inputs = tensor.random_normal((batch_size, 10))
-    
-    # Initialize state
-    state = tensor.zeros((batch_size, 20))
-    
-    # Forward pass
-    output, new_state = cell(inputs, state)
-    
-    print(f"Input shape: {tensor.shape(inputs)}")
-    print(f"Output shape: {tensor.shape(output)}")
-    print(f"State shape: {tensor.shape(new_state)}")
-    
-    return output, new_state
 
 def test_stride_aware_layer():
     """Test the StrideAware layer."""
@@ -79,12 +52,8 @@ def test_stride_aware_layer():
     return outputs, final_state
 
 if __name__ == "__main__":
-    print("Testing StrideAware classes for multi-timescale processing...")
-    
-    # Test cell
-    cell_output, cell_state = test_stride_aware_cell()
-    
-    # Test layer
+    print("Testing StrideAware layer for multi-timescale processing...")
+
     layer_output, layer_state = test_stride_aware_layer()
     
     print("\nAll tests completed successfully!")

--- a/ember_ml/nn/features/bigquery_feature_extractor.py
+++ b/ember_ml/nn/features/bigquery_feature_extractor.py
@@ -1,0 +1,114 @@
+"""Simplified BigQuery feature extractor."""
+
+from typing import List, Optional, Tuple, Any
+
+import pandas as pd
+
+from ember_ml.nn.features.column_feature_extraction import ColumnFeatureExtractor
+from ember_ml.nn.features import bigquery
+from ember_ml.nn import tensor
+from ember_ml import ops
+
+
+class BigQueryFeatureExtractor(ColumnFeatureExtractor):
+    """Feature extractor for Google BigQuery tables."""
+
+    def __init__(
+        self,
+        project_id: str,
+        dataset_id: str,
+        table_id: str,
+        credentials_path: Optional[str] = None,
+        numeric_columns: Optional[List[str]] = None,
+        categorical_columns: Optional[List[str]] = None,
+        datetime_columns: Optional[List[str]] = None,
+        target_column: Optional[str] = None,
+        device: Optional[str] = None,
+    ) -> None:
+        super().__init__()
+        self.project_id = project_id
+        self.dataset_id = dataset_id
+        self.table_id = table_id
+        self.credentials_path = credentials_path
+        self.numeric_columns = numeric_columns or []
+        self.categorical_columns = categorical_columns or []
+        self.datetime_columns = datetime_columns or []
+        self.target_column = target_column
+        self.device = device
+        self._client = None
+
+    # --- BigQuery helpers ---
+    def initialize_client(self) -> Any:
+        self._client = bigquery.initialize_client(self.project_id, self.credentials_path)
+        return self._client
+
+    def execute_query(self, query: str) -> pd.DataFrame:
+        if self._client is None:
+            self.initialize_client()
+        return bigquery.execute_query(self._client, query)
+
+    def fetch_table_schema(self) -> dict:
+        if self._client is None:
+            self.initialize_client()
+        return bigquery.fetch_table_schema(self._client, self.dataset_id, self.table_id)
+
+    # --- Column management ---
+    def auto_detect_column_types(self) -> None:
+        schema = self.fetch_table_schema()
+        for name, col_type in schema.items():
+            if name == self.target_column:
+                continue
+            if col_type in {"FLOAT", "INTEGER", "NUMERIC", "BIGNUMERIC"}:
+                self.numeric_columns.append(name)
+            elif col_type in {"DATETIME", "DATE", "TIMESTAMP"}:
+                self.datetime_columns.append(name)
+            else:
+                self.categorical_columns.append(name)
+        self.numeric_columns = sorted(set(self.numeric_columns))
+        self.categorical_columns = sorted(set(self.categorical_columns))
+        self.datetime_columns = sorted(set(self.datetime_columns))
+
+    # --- Data fetching ---
+    def fetch_data(self, limit: Optional[int] = None) -> pd.DataFrame:
+        query = f"SELECT * FROM `{self.dataset_id}.{self.table_id}`"
+        if limit is not None:
+            query += f" LIMIT {limit}"
+        return self.execute_query(query)
+
+    # --- Feature extraction ---
+    def extract_features(
+        self,
+        data: Optional[pd.DataFrame] = None,
+        limit: Optional[int] = None,
+        handle_missing: bool = True,
+        handle_outliers: bool = True,
+        normalize: bool = True,
+    ) -> Tuple[tensor.EmberTensor, List[str]]:
+        if data is None:
+            data = self.fetch_data(limit=limit)
+        numeric_tensor, numeric_names = bigquery.process_numeric_features(
+            data,
+            self.numeric_columns,
+            handle_missing=handle_missing,
+            handle_outliers=handle_outliers,
+            normalize=normalize,
+            device=self.device,
+        ) if self.numeric_columns else (None, [])
+        categorical_tensor, categorical_names = bigquery.process_categorical_features(
+            data,
+            self.categorical_columns,
+            handle_missing=handle_missing,
+            device=self.device,
+        ) if self.categorical_columns else (None, [])
+        datetime_tensor, datetime_names = bigquery.process_datetime_features(
+            data,
+            self.datetime_columns,
+            device=self.device,
+        ) if self.datetime_columns else (None, [])
+
+        tensors = [t for t in [numeric_tensor, categorical_tensor, datetime_tensor] if t is not None]
+        names = numeric_names + categorical_names + datetime_names
+        if not tensors:
+            raise ValueError("No features to extract")
+        features = tensor.concatenate(tensors, axis=1) if len(tensors) > 1 else tensors[0]
+        return features, names

--- a/ember_ml/nn/modules/__init__.py
+++ b/ember_ml/nn/modules/__init__.py
@@ -8,9 +8,8 @@ Available Modules:
         GRUCell: Gated Recurrent Unit cell
         
     Specialized Cells:
-        StrideAware: Stride-aware cell base class
-        StrideAwareCfC: Stride-aware Closed-form Continuous-time cell
-        StrideAwareCell: Stride-aware general cell
+        StrideAware: Stride-aware recurrent layer
+        StrideAwareCfC: Stride-aware Closed-form Continuous-time layer
         
     Advanced Modules:
         CfC: Closed-form Continuous-time cell

--- a/ember_ml/nn/modules/rnn/stride_aware.py
+++ b/ember_ml/nn/modules/rnn/stride_aware.py
@@ -1,24 +1,21 @@
 """
 Stride-Aware Layer
 
-This module provides an implementation of the StrideAware layer,
-which wraps a StrideAwareCell to create a recurrent layer.
+This module provides an implementation of the :class:`StrideAware` layer
+for multi-timescale processing.
 """
 
 # Removed unused imports
 
 # Removed numpy import
 from ember_ml import ops
-from ember_ml.nn.modules import Module
+from ember_ml.nn.modules import Module, Parameter
 # Removed stride_aware_cell import
 from ember_ml.nn import tensor
 
 class StrideAware(Module):
     """
-    Stride-Aware RNN layer.
-    
-    This layer wraps a StrideAwareCell to create a recurrent layer
-    that can handle different timescales.
+    Stride-Aware RNN layer capable of handling different timescales.
     """
     
     def __init__(
@@ -59,7 +56,7 @@ class StrideAware(Module):
         self.return_sequences = return_sequences
         self.batch_first = batch_first
         
-        # StrideAwareCell parameters
+        # Layer parameters
         self.activation = activation
         self.bias = bias
         self.use_bias = use_bias
@@ -74,22 +71,22 @@ class StrideAware(Module):
         from ember_ml.nn.initializers import glorot_uniform
         
         # Input weights
-        self.input_kernel = tensor.Parameter(glorot_uniform((self.input_size, self.hidden_size)))
+        self.input_kernel = Parameter(glorot_uniform((self.input_size, self.hidden_size)))
         
         # Hidden weights
-        self.hidden_kernel = tensor.Parameter(glorot_uniform((self.hidden_size, self.hidden_size)))
+        self.hidden_kernel = Parameter(glorot_uniform((self.hidden_size, self.hidden_size)))
         
         # Output weights
-        self.output_kernel = tensor.Parameter(glorot_uniform((self.hidden_size, self.hidden_size)))
+        self.output_kernel = Parameter(glorot_uniform((self.hidden_size, self.hidden_size)))
         
         # Bias terms
         if self.use_bias:
-            self.input_bias = tensor.Parameter(tensor.zeros((self.hidden_size,)))
-            self.hidden_bias = tensor.Parameter(tensor.zeros((self.hidden_size,)))
-            self.output_bias = tensor.Parameter(tensor.zeros((self.hidden_size,)))
+            self.input_bias = Parameter(tensor.zeros((self.hidden_size,)))
+            self.hidden_bias = Parameter(tensor.zeros((self.hidden_size,)))
+            self.output_bias = Parameter(tensor.zeros((self.hidden_size,)))
         
         # Time constant
-        self.tau = tensor.Parameter(tensor.ones((self.hidden_size,)))
+        self.tau = Parameter(tensor.ones((self.hidden_size,)))
     
     def forward(self, inputs, initial_state=None, elapsed_time=1.0):
         """

--- a/ember_ml/ops/__init__.py
+++ b/ember_ml/ops/__init__.py
@@ -138,6 +138,36 @@ irfft2 = ops_module.irfft2
 rfftn = ops_module.rfftn
 irfftn = ops_module.irfftn
 
+# Provide simple random namespace for compatibility
+class _RandomNamespace:
+    def uniform(self, minval: float = 0.0, maxval: float = 1.0, shape=()):
+        from ember_ml.nn.tensor import random_uniform, squeeze
+        minval = float(getattr(minval, "item", lambda: minval)()) if not isinstance(minval, (int, float)) else minval
+        maxval = float(getattr(maxval, "item", lambda: maxval)()) if not isinstance(maxval, (int, float)) else maxval
+        if shape == ():
+            tensor = random_uniform((1,), minval=minval, maxval=maxval)
+            return float(squeeze(tensor).item())
+        return random_uniform(shape, minval=minval, maxval=maxval)
+
+    def normal(self, shape=(), mean: float = 0.0, stddev: float = 1.0):
+        from ember_ml.nn.tensor import random_normal, squeeze
+        mean = float(getattr(mean, "item", lambda: mean)()) if not isinstance(mean, (int, float)) else mean
+        stddev = float(getattr(stddev, "item", lambda: stddev)()) if not isinstance(stddev, (int, float)) else stddev
+        if shape == ():
+            tensor = random_normal((1,), mean=mean, stddev=stddev)
+            return float(squeeze(tensor).item())
+        return random_normal(shape, mean=mean, stddev=stddev)
+
+random = _RandomNamespace()
+
+# Alias tensor indexing helpers for convenience
+from ember_ml.nn import tensor as _tensor
+
+def index_update(tensor_obj, indices, value):
+    return _tensor.index_update(tensor_obj, indices, value)
+
+index = _tensor.index
+
 
 # Master list of all operations for __all__
 _MASTER_OPS_LIST = [
@@ -161,11 +191,12 @@ _MASTER_OPS_LIST = [
     'normalize_vector', 'compute_energy_stability', 'compute_interference_strength', 'compute_phase_coherence',
     'partial_interference', 'euclidean_distance', 'cosine_similarity', 'exponential_decay', 'fft', 'ifft',
     'fft2', 'ifft2', 'fftn', 'ifftn', 'rfft', 'irfft', 'rfft2', 'irfft2', 'rfftn', 'irfftn',
+    'index_update', 'index',
 ]
 
 # Define __all__ to include backend controls, pi, submodules, and all operations
 __all__ = [
     'set_backend', 'get_backend', 'auto_select_backend',  # Backend controls
     'pi',  # Constants
-    'stats', 'linearalg', 'bitwise',  # Submodules
+    'stats', 'linearalg', 'bitwise', 'random',  # Submodules
 ] + _MASTER_OPS_LIST  # All operations


### PR DESCRIPTION
## Summary
- drop `StrideAwareCell` and update stride-aware utilities
- implement simplified `BigQueryFeatureExtractor`
- re-export BigQuery extractor from compatibility package
- update docs to describe stride-aware *layers*
- fix stride-aware test

## Testing
- `pytest -c tests/pytest.ini ember_ml/models/attention/test_stride_aware.py::test_stride_aware_layer -q`
- `pytest -c tests/pytest.ini ember_ml/models/attention/test_temporal_stride_processor -q` *(fails: file not found)*
- `pytest -c tests/pytest.ini -q` *(fails: multiple missing dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_6844b2ef5818833399bc4d8c392706f4