### PR TITLE
Fix: Ensure backend purity in actor and asyncml modules

### DIFF
--- a/ember_ml/actors/supervisor/sequence_processor_actor.py
+++ b/ember_ml/actors/supervisor/sequence_processor_actor.py
@@ -7,7 +7,6 @@ import asyncio
 import time
 import uuid
 from typing import Dict, List, Any, Optional
-import mlx.core as mx # Keep mlx import for now, as EmberTensor might wrap it
 
 # Import EmberTensor and ops
 from ember_ml.nn.tensor import EmberTensor

--- a/ember_ml/actors/task/metal_kernel_actor.py
+++ b/ember_ml/actors/task/metal_kernel_actor.py
@@ -4,7 +4,6 @@ utilizing asynchronous neural network modules.
 """
 
 import ray
-import mlx.core as mx
 import time
 import asyncio
 from typing import Dict, List, Optional, Any
@@ -14,10 +13,7 @@ from ember_ml.nn.tensor import EmberTensor
 from ember_ml.asyncml.nn.modules.rnn.liquid_cfc_xlstm import async_liquid_cfc_xlstm
 from ember_ml.ops import stats
 from ember_ml.nn.tensor.types import TensorLike
-import ray
-import time
-import asyncio
-from typing import Dict, List, Optional, Any
+# Removed duplicate imports of ray, time, asyncio, typing
 from ember_ml import ops
 @ray.remote
 class MetalKernelActor:

--- a/ember_ml/asyncml/client/client.py
+++ b/ember_ml/asyncml/client/client.py
@@ -7,8 +7,6 @@ import ray
 import asyncio
 import time
 from typing import Dict, List, Any, Optional
-import mlx.core as mx # Keep mlx import for now, as EmberTensor might wrap it
-import numpy as np
  
 # Import EmberTensor
 from ember_ml.nn.tensor import EmberTensor


### PR DESCRIPTION
This pull request focuses on cleaning up unused and duplicate imports across multiple files in the `ember_ml` package. The changes improve code readability and maintainability by removing redundant lines.

### Cleanup of unused and duplicate imports:

* [`ember_ml/actors/supervisor/sequence_processor_actor.py`](diffhunk://#diff-3ac601f5591c79cb1bc22901b88aa412dcf1b03b0ade1ffb717d8b712855adc0L10): Removed the unused `mlx.core` import, which was previously kept for potential future use.
* [`ember_ml/actors/task/metal_kernel_actor.py`](diffhunk://#diff-4564530f8ea724644ca77f6a3de3f20d64207018d13d57f0494744100a181f25L17-R16): Removed duplicate imports of `ray`, `time`, `asyncio`, and `typing`, ensuring the file only includes necessary imports.
* [`ember_ml/asyncml/client/client.py`](diffhunk://#diff-5f51071f0d73ab0f4f8d94497f1f4efa0da86d96b31791e38cff180e03142ea3L10-L11): Removed unused imports of `mlx.core` and `numpy`, simplifying the import statements.I've removed direct imports of backend-specific libraries (mlx, numpy) from the following frontend modules:
- ember_ml/actors/supervisor/sequence_processor_actor.py
- ember_ml/actors/task/metal_kernel_actor.py
- ember_ml/asyncml/client/client.py
