### PR TITLE
Use relative imports for Sequential layer

### DIFF
--- a/ember_ml/nn/layers/sequential.py
+++ b/ember_ml/nn/layers/sequential.py
@@ -8,11 +8,10 @@ that works with any backend (NumPy, PyTorch, MLX).
 from typing import Optional, Union, Tuple, Any, Dict, List, Sequence
 
 # Import necessary layer modules for from_config reconstruction
-import linear
-from ember_ml.nn import activations
-from typing import Dict, Any, List # Ensure these are imported if not already
-from ember_ml.nn.modules import Module
-from ember_ml import tensor
+from . import linear
+from ..modules import Module, activations
+from typing import Dict, Any, List  # Ensure these are imported if not already
+from ... import tensor
 class Sequential(Module):
     """
     A sequential container.
@@ -226,7 +225,7 @@ class Sequential(Module):
     def __len__(self) -> int:
         """
         Get the number of layers in the container.
-        
+
         Returns:
             Number of layers
         """

--- a/tests/test_sequential_import.py
+++ b/tests/test_sequential_import.py
@@ -1,0 +1,6 @@
+import importlib
+
+def test_sequential_import():
+    module = importlib.import_module("ember_ml.nn.layers.sequential")
+    assert hasattr(module, "Sequential")
+


### PR DESCRIPTION
## Summary
- use relative imports within `ember_ml.nn.layers.sequential`
- add regression test ensuring sequential module imports

## Testing
- `pytest tests/test_sequential_import.py -q` *(fails: ImportError: cannot import name 'int32')*
- `python tests/test_sequential_import.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3f024bcd88333917f91605500840e