### PR TITLE
Use backend-safe device lookup for sin/cos transform

### DIFF
--- a/ember_ml/utils/backend_utils.py
+++ b/ember_ml/utils/backend_utils.py
@@ -94,20 +94,31 @@ def sin_cos_transform(values: Any, period: float = 1.0) -> Tuple[Any, Any]:
     Returns:
         Tuple of (sin_values, cos_values) as EmberTensors
     """
-    values_tensor = tensor.convert_to_tensor(values) # Ensure it's an EmberTensor
-    
+    values_tensor = tensor.convert_to_tensor(values)  # Ensure it's an EmberTensor
+
+    # Determine dtype and device safely without direct attribute access
+    try:
+        device = ops.get_device(values_tensor)
+    except Exception:
+        device = getattr(values_tensor, "device", None)
+
+    try:
+        dtype = ops.dtype(values_tensor)
+    except Exception:
+        dtype = getattr(values_tensor, "dtype", None)
+
     # Ensure constants are tensors of the same dtype and device for ops
     # ops.pi is likely a float, ensure it's converted correctly
     # The ops functions (multiply, divide, sin, cos) should handle broadcasting of scalar constants
     # if values_tensor is an EmberTensor. However, explicit conversion is safer for backend purity.
 
-    two_pi_val = 2 * ops.pi # Python float
+    two_pi_val = 2 * ops.pi  # Python float
 
     # Let ops handle scalar broadcasting if possible, assuming period is float
     # arg = ops.divide(ops.multiply(two_pi_val, values_tensor), period)
     # For stricter backend purity, convert all scalars to tensors:
-    two_pi_tensor = tensor.convert_to_tensor(two_pi_val, dtype=values_tensor.dtype, device=values_tensor.device)
-    period_tensor = tensor.convert_to_tensor(period, dtype=values_tensor.dtype, device=values_tensor.device)
+    two_pi_tensor = tensor.convert_to_tensor(two_pi_val, dtype=dtype, device=device)
+    period_tensor = tensor.convert_to_tensor(period, dtype=dtype, device=device)
 
     term_mul = ops.multiply(two_pi_tensor, values_tensor)
     arg = ops.divide(term_mul, period_tensor)

--- a/tests/test_sin_cos_transform.py
+++ b/tests/test_sin_cos_transform.py
@@ -1,0 +1,32 @@
+import pytest
+import numpy as np
+
+from ember_ml.utils import backend_utils
+from ember_ml import tensor, ops
+from ember_ml.ops import set_backend, get_backend
+
+
+@pytest.mark.parametrize("backend", ["numpy", "torch", "mlx"])
+def test_sin_cos_transform_across_backends(backend):
+    """Ensure sin_cos_transform works for multiple backends."""
+    if backend == "mlx":
+        pytest.importorskip("mlx.core")
+    original_backend = get_backend()
+    set_backend(backend)
+    try:
+        values = [0.0, 0.25, 0.5, 0.75]
+        sin_vals, cos_vals = backend_utils.sin_cos_transform(values, period=1.0)
+
+        expected_sin = np.sin(2 * np.pi * np.array(values))
+        expected_cos = np.cos(2 * np.pi * np.array(values))
+
+        assert np.allclose(tensor.to_numpy(sin_vals), expected_sin, atol=1e-6)
+        assert np.allclose(tensor.to_numpy(cos_vals), expected_cos, atol=1e-6)
+
+        input_tensor = tensor.convert_to_tensor(values)
+        assert ops.get_device(sin_vals) == ops.get_device(input_tensor)
+        assert ops.get_device(cos_vals) == ops.get_device(input_tensor)
+        assert ops.dtype(sin_vals) == ops.dtype(input_tensor)
+        assert ops.dtype(cos_vals) == ops.dtype(input_tensor)
+    finally:
+        set_backend(original_backend)


### PR DESCRIPTION
## Summary
- make `sin_cos_transform` backend-safe by replacing direct `.device` access with `ops.get_device` and fallback lookups
- add cross-backend unit tests for `sin_cos_transform`

## Testing
- `pytest tests/test_sin_cos_transform.py -q` *(fails: ImportError: cannot import name 'int32' from partially initialized module 'ember_ml')*

------
https://chatgpt.com/codex/tasks/task_e_68b3f47693b08333ab1674265e64d327