### PR TITLE
Use backend-agnostic dtype default in vstack_safe

### DIFF
--- a/docs/api/utilities.md
+++ b/docs/api/utilities.md
@@ -13,7 +13,7 @@ Provides utility functions for working with Ember ML's backend system.
 *   **`tensor_to_numpy_safe(tensor)`**: Safely converts a tensor from any backend to a NumPy array, handling different backend tensor types and devices (like PyTorch MPS).
 *   **`random_uniform(shape, low, high)`**: Generates uniform random values using the current backend.
 *   **`sin_cos_transform(values, period)`**: Applies sine and cosine transformations for cyclical features using `ops`.
-*   **`vstack_safe(arrays)`**: Safely stacks a list of arrays vertically using the current backend, handling potential shape mismatches.
+*   **`vstack_safe(arrays)`**: Safely stacks a list of arrays vertically using the current backend, handling potential shape mismatches and defaulting to `tensor.float32` when a dtype isn't provided.
 *   **`get_backend_info()`**: Gets information about the current backend (name, device).
 *   **`print_backend_info()`**: Prints information about the current backend and performs a simple test operation.
 

--- a/ember_ml/utils/backend_utils.py
+++ b/ember_ml/utils/backend_utils.py
@@ -131,21 +131,23 @@ def sin_cos_transform(values: Any, period: float = 1.0) -> Tuple[Any, Any]:
 def vstack_safe(arrays: List[Any]) -> Optional[tensor.EmberTensor]: # Return type updated
     """
     Safely stack arrays vertically using the current backend.
-    
+
     Args:
         arrays: List of arrays to stack
-        
+
     Returns:
-        Stacked array in the current backend format
+        Stacked array in the current backend format. When input items are not
+        already tensors, they are converted using :func:`tensor.convert_to_tensor`
+        with :data:`tensor.float32` as the default ``dtype``.
     """
     if not arrays:
         return None # Or return an empty tensor: tensor.zeros((0,)) etc.
 
     # Convert all arrays in the list to EmberTensors
     # Assume a default dtype if not specified and items are not already EmberTensors
-    # For safety, let's try to infer dtype from the first tensor if possible, or use float32
-    first_item_device = ops.get_device() # Default device
-    first_item_dtype = tensor.EmberDType.float32 # Default dtype
+    # For safety, try to infer dtype from the first tensor; otherwise use tensor.float32
+    first_item_device = ops.get_device()  # Default device
+    first_item_dtype = tensor.float32  # Backend-agnostic default dtype
 
     if arrays and isinstance(arrays[0], tensor.EmberTensor):
         first_item_device = arrays[0].device
@@ -219,5 +221,5 @@ def print_backend_info() -> None:
     a = tensor.ones((2, 2))
     b = tensor.ones((2, 2))
     c = ops.matmul(a, b)
-    
+
     print(f"Test operation: {a} @ {b} = {c}")


### PR DESCRIPTION
## Summary
- use `tensor.float32` instead of `EmberDType.float32` as the fallback dtype in `vstack_safe`
- document the backend‑agnostic dtype default in code and utilities docs

## Testing
- `python -m py_compile ember_ml/utils/backend_utils.py`
- `pytest tests/numpy_tests/test_numpy_utils_backend_utils.py -q` *(fails: ImportError: cannot import name 'int32' from partially initialized module 'ember_ml')*

------
https://chatgpt.com/codex/tasks/task_e_68b3f6d45ba88333829a21d941dd2592