### PR TITLE
Import stats in metrics utilities

### DIFF
--- a/ember_ml/utils/metrics.py
+++ b/ember_ml/utils/metrics.py
@@ -8,6 +8,7 @@ from typing import Union, List, Tuple, Optional, Dict, Any
 from ember_ml.nn import tensor
 from ember_ml.nn.tensor.types import TensorLike
 from ember_ml import ops
+from ember_ml.ops import stats
 
 # Import sklearn metrics that we haven't implemented yet
 from sklearn.metrics import (


### PR DESCRIPTION
## Summary
- import `stats` from `ember_ml.ops` within metrics utilities to resolve NameError

## Testing
- `pytest tests/mlx_tests/test_mlx_ops_stats.py -q` *(skipped: MLX backend disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68b41f2e69248333be5d0f6e605f1568