### PR TITLE
Expose callable tensor function mirroring torch API

### DIFF
--- a/ember_ml/__init__.py
+++ b/ember_ml/__init__.py
@@ -64,6 +64,22 @@ from ember_ml import utils
 from ember_ml import asyncml
 
 
+class _TensorProxy:
+    """Callable wrapper around :mod:`ember_ml.tensor` mimicking ``torch.tensor``."""
+
+    def __init__(self):
+        self._module = importlib.import_module("ember_ml.tensor")
+
+    def __getattr__(self, name):  # pragma: no cover - simple delegation
+        return getattr(self._module, name)
+
+    def __call__(self, *args, **kwargs):
+        return self._module.convert_to_tensor(*args, **kwargs)
+
+
+tensor = _TensorProxy()
+
+
 def set_seed(seed):
     """Set the random seed for all backends."""
     from ember_ml import tensor
@@ -85,5 +101,6 @@ __all__ = [
     'visualization',
     'utils',
     'asyncml',
+    'tensor',
     '__version__'
 ]

--- a/ember_ml/tensor/__init__.py
+++ b/ember_ml/tensor/__init__.py
@@ -285,12 +285,19 @@ def convert_to_tensor(
     return _convert_to_backend_tensor(data, dtype=dtype, device=device)
 
 
+def tensor(data: Any, dtype: Any = None, device: Optional[str] = None) -> Any:
+    """Create a tensor from data, mirroring ``torch.tensor`` semantics."""
+
+    return convert_to_tensor(data, dtype=dtype, device=device)
+
+
 __all__ = [
     "EmberTensor",
     "EmberDType",
     "DType",
     "dtype",
     "array",
+    "tensor",
     "convert_to_tensor",
     "zeros",
     "ones",


### PR DESCRIPTION
## Summary
- Wrap `ember_ml.tensor` submodule in a callable proxy so `ember_ml.tensor(...)` constructs tensors like `torch.tensor`
- Add explicit `tensor` function in the tensor module delegating to `convert_to_tensor`

## Testing
- `pytest tests/test_convert_to_tensor.py tests/test_ember_tensor_api_structure.py` *(fails: NameError for EmberTensor and missing backends torch/mlx)*

------
https://chatgpt.com/codex/tasks/task_e_68c54090d6588333b742d4353c6a9575