### PR TITLE
docs: sync docs with API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The project includes tools for extracting features from BigQuery tables, includi
 2. Install the required packages: `pip install -r requirements.txt`
 3. Choose your backend:
    ```python
-   from ember_ml.backend import set_backend
+   from ember_ml import set_backend
    
    # Use MLX (optimized for Apple Silicon)
    set_backend('mlx')
@@ -88,4 +88,3 @@ x = ops.random.normal(shape=(100, 10))
 output = model(x)
 ```
 
-=======

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -4,54 +4,16 @@ This section contains detailed API documentation for Ember ML.
 
 ## Core Modules
 
-- **`ember_ml.ops`**: Core operations for tensor manipulation
-  - `tensor`: Tensor creation and manipulation
-  - `math`: Mathematical operations
-  - `random`: Random number generation
-  - `solver`: Linear algebra operations
-
-- **`ember_ml.backend`**: Backend abstraction system
-  - `numpy`: NumPy backend implementation
-  - `torch`: PyTorch backend implementation
-  - `mlx`: MLX backend implementation
-  - `ember`: Ember backend implementation
-
-- **`ember_ml.features`**: Feature extraction and processing
-  - `TerabyteFeatureExtractor`: Extracts features from large datasets
-  - `TemporalStrideProcessor`: Processes temporal data with variable strides
-  - `GenericFeatureEngineer`: General-purpose feature engineering
-  - `GenericTypeDetector`: Automatic column type detection
-
-- **`ember_ml.models`**: Machine learning models
-  - `liquid`: Liquid neural networks
-  - `rbm`: Restricted Boltzmann Machines
-
-## Neural Network Components
-
-- **`ember_ml.core`**: Core neural implementations
-  - `ltc`: Liquid Time Constant neurons
-  - `geometric`: Geometric processing
-  - `spherical_ltc`: Spherical variants
-  - `stride_aware_cfc`: Stride-Aware Continuous-time Fully Connected cells
-
-- **`ember_ml.attention`**: Attention mechanisms
-  - `temporal`: Time-based attention
-  - `causal`: Causal attention
-  - `multiscale_ltc`: Multiscale LTC attention
-
-- **`ember_ml.nn`**: Neural network components
-  - `wirings`: Network connectivity patterns
-  - `modules`: Neural network modules
-
-## Utility Modules
-
-- **`ember_ml.utils`**: Utility functions
-  - `math_helpers`: Mathematical utilities
-  - `metrics`: Evaluation metrics
-  - `visualization`: Plotting tools
-
-- **`ember_ml.initializers`**: Weight initialization
-  - `glorot`: Glorot/Xavier initialization
-  - `binomial`: Binomial initialization
+- **`ember_ml.tensor`**: Backend‑agnostic tensor wrapper and creation helpers
+- **`ember_ml.ops`**: Unified interface to mathematical operations and backend management
+- **`ember_ml.nn`**: Neural network building blocks such as layers, wirings, and activations
+- **`ember_ml.models`**: Pre-built model architectures
+- **`ember_ml.training`**: Training utilities like optimizers and loops
+- **`ember_ml.data`**: Data loading and dataset helpers
+- **`ember_ml.utils`**: Utility functions including metrics and math helpers
+- **`ember_ml.visualization`**: Plotting and visualization utilities
+- **`ember_ml.asyncml`**: Asynchronous model and actor components
+- **`ember_ml.features`**: Feature extraction and preprocessing tools
 
 For detailed documentation on specific functions and classes, refer to the docstrings in the source code.
+

--- a/docs/api/ops.md
+++ b/docs/api/ops.md
@@ -145,8 +145,8 @@ The `ops` module also re-exports key backend management functions:
 - All operations are backend-agnostic and work with any backend (NumPy, PyTorch, MLX) set via `ops.set_backend`.
 - The operations follow a consistent API across different backends.
 - Most operations support broadcasting, similar to NumPy and other array libraries.
-- For tensor creation and manipulation (which return `EmberTensor`), use the `ember_ml.nn.tensor` module.
-- For statistical operations (e.g., mean, std, var), use the `ember_ml.ops.stats` module.
-- For linear algebra operations (e.g., svd, inv, det), use the `ember_ml.ops.linearalg` module.
+- For tensor creation and manipulation (which return `EmberTensor`), use the `ember_ml.tensor` module.
+- For statistical operations (e.g., mean, std, var), use the `ember_ml.stats` module.
+- For linear algebra operations (e.g., svd, inv, det), use the `ember_ml.linearalg` module.
 - For activation functions (functional or Module classes), use the `ember_ml.nn.modules.activations` module.
-- For feature extraction operations/factories, use the `ember_ml.nn.features` module.
+- For feature extraction operations/factories, use the `ember_ml.features` module.

--- a/docs/api/tensor.md
+++ b/docs/api/tensor.md
@@ -1,6 +1,6 @@
 # Tensor Module
 
-The `ember_ml.nn.tensor` module provides a backend-agnostic tensor implementation that works with any backend (NumPy, PyTorch, MLX) using the backend abstraction layer.
+The `ember_ml.tensor` module provides a backend-agnostic tensor implementation that works with any backend (NumPy, PyTorch, MLX) using the backend abstraction layer.
 
 ## Overview
 
@@ -14,7 +14,7 @@ The tensor module is designed to provide a consistent API for tensor operations 
 
 The tensor module follows the backend abstraction architecture of Ember ML:
 
-1. **Frontend Abstractions**: The `ember_ml.nn.tensor` module provides abstract interfaces and common implementations
+1. **Frontend Abstractions**: The `ember_ml.tensor` module provides abstract interfaces and common implementations
 2. **Backend Implementations**: The actual implementations reside in the backend directory, with specific implementations for each supported backend (NumPy, PyTorch, MLX)
 3. **Dispatch Mechanism**: The frontend abstractions dispatch calls to the appropriate backend implementation based on the currently selected backend
 
@@ -174,10 +174,10 @@ tensor = tensor([[1, 2, 3], [4, 5, 6]], device='mps')   # Apple Silicon GPU
 
 ## Backend Selection
 
-The tensor module uses the current backend selected by the `ember_ml.backend` module. You can change the backend using the `set_backend` function:
+The tensor module uses the current backend selected via the top-level `set_backend` function:
 
 ```python
-from ember_ml.backend import set_backend
+from ember_ml import set_backend
 
 # Set the backend to PyTorch
 set_backend('torch')

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -57,15 +57,12 @@ print(z)
 Ember ML automatically selects the best backend based on your hardware:
 
 ```python
-from ember_ml.backend import get_backend
-
 # Get the current backend
+from ember_ml.ops import get_backend, set_backend
 backend = get_backend()
 print(f"Using backend: {backend}")
 
 # Manually set a backend
-from ember_ml.ops import set_backend
-
 # Set to NumPy backend
 set_backend('numpy')
 print(f"Now using backend: {get_backend()}")


### PR DESCRIPTION
## Summary
- update README getting started to import `set_backend` from package root
- refresh API index and ops notes to reference new modules
- fix tensor docs and tutorial for new backend API

## Testing
- `pytest` *(fails: AttributeError: module 'ember_ml.backend.numpy.tensor' has no attribute ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c62fef89a08333a4792ff349f03d8a